### PR TITLE
Add Command#execute

### DIFF
--- a/lib/mercenary/command.rb
+++ b/lib/mercenary/command.rb
@@ -143,8 +143,8 @@ module Mercenary
 
     # Public: Execute all actions given the inputted args and options
     #
-    # argv - command-line args (sans opts)
-    # config - the Hash configuration of string key to value
+    # argv - (optional) command-line args (sans opts)
+    # config - (optional) the Hash configuration of string key to value
     #
     # Returns nothing
     def execute(argv = [], config = {})


### PR DESCRIPTION
Command#execute calls all of the actions that the Command has with the (optional) Array argv and Hash config parameters.
