### PR TITLE
Added missing comma to fix '-v' and '--version' options

### DIFF
--- a/lib/mercenary/program.rb
+++ b/lib/mercenary/program.rb
@@ -36,7 +36,7 @@ module Mercenary
       @optparse = OptionParser.new do |opts|
         cmd = super(argv, opts, @config)
 
-        opts.on('-v' '--version', 'Print the version') do
+        opts.on('-v', '--version', 'Print the version') do
           puts "#{name} #{version}"
           abort
         end


### PR DESCRIPTION
A comma was missing in the options parser that caused the '-v' and '--version' options to fail when using Mercenary. The "--version" option would fail with something like:

```
$ mercenary_example --version
mercenary_example: version unknown
```

And the '-v' version would fail with something like:

```
.../gems/mercenary-0.2.0/lib/mercenary/program.rb:45:in `go': missing argument: -v (OptionParser::MissingArgument)
```

Adding the comma fixes both issues so that both '-v' and '--version' work as expected.
