### PR TITLE
Setup so logging level state is maintained and can be set by the script utilizing Mercenary.

### DIFF
--- a/examples/logging.rb
+++ b/examples/logging.rb
@@ -1,0 +1,39 @@
+#!/usr/bin/env ruby
+
+$:.unshift File.join(File.dirname(__FILE__), *%w{ .. lib })
+
+require "mercenary"
+
+# This example sets the logging mode of mercenary to
+# debug. Logging messages from "p.logger.debug" will
+# be output to STDOUT.
+
+Mercenary.program(:logger_output) do |p|
+
+  p.version "#.#.#"
+  p.description 'An example of turning on logging for Mercenary.'
+  p.syntax 'logger_output'
+
+
+  p.logger.info "The default log level is INFO. So this will output."
+  p.logger.debug "Since DEBUG is below INFO, this will not output."
+
+  p.logger(Logger::DEBUG)
+  p.logger.debug "Logger level now set to DEBUG. So everything will output."
+  
+  p.logger.debug    "Example of DEBUG level message."
+  p.logger.info     "Example of INFO level message."
+  p.logger.warn     "Example of WARN level message."
+  p.logger.error    "Example of ERROR level message."
+  p.logger.fatal    "Example of FATAL level message."
+  p.logger.unknown  "Example of UNKNOWN level message."
+
+  p.action do |args, options|
+    
+    p.logger(Logger::INFO)
+    p.logger.debug "Logger level back to INFO. This line will not output."
+    p.logger.info "This INFO message will output."
+
+  end
+
+end

--- a/lib/mercenary/command.rb
+++ b/lib/mercenary/command.rb
@@ -112,15 +112,23 @@ module Mercenary
     # level - the logger level (a Logger constant, see docs for more info)
     #
     # Returns the instance of Logger
-    def logger(level = Logger::INFO)
+    def logger(level = nil)
       unless @logger
         @logger = Logger.new(STDOUT)
         @logger.formatter = proc do |severity, datetime, progname, msg|
           "#{ident} (#{severity}): #{msg}\n"
         end
+
+        if level == nil
+          @logger.level = Logger::INFO
+        end
+
       end
 
-      @logger.level = level
+      unless level.nil? 
+        @logger.level = level
+      end
+
       @logger
     end
 


### PR DESCRIPTION
- Updated the "logger" method in the command.rb file so that the log level maintains state between calls instead of reverting to INFO unless explicitly defined for each call. (The default level is still set to INFO the first time a logger is called. 
- Created an examples directory and a 'logging.rb' file demonstrating how to use the logging feature.
