### PR TITLE
Allow Commands to have versions.

### DIFF
--- a/lib/mercenary/command.rb
+++ b/lib/mercenary/command.rb
@@ -25,6 +25,16 @@ module Mercenary
       @parent = parent
     end
 
+    # Public: Sets or gets the command version
+    #
+    # version - the command version (optional)
+    #
+    # Returns the version and sets it if an argument is non-nil
+    def version(version = nil)
+      @version = version if version
+      @version
+    end
+
     # Public: Sets or gets the syntax string
     #
     # syntax - the string which describes this command's usage syntax (optional)

--- a/lib/mercenary/program.rb
+++ b/lib/mercenary/program.rb
@@ -13,16 +13,6 @@ module Mercenary
       super(name)
     end
 
-    # Public: Sets or gets the program version
-    #
-    # version - the program version (optional)
-    #
-    # Returns the version and sets it if an argument is present
-    def version(version = nil)
-      @version = version if version
-      @version
-    end
-
     # Public: Run the program
     #
     # argv - an array of string args (usually ARGV)

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -35,6 +35,12 @@ describe(Mercenary::Command) do
       expect(add_sub.call(command).parent).to eq(command)
     end
 
+    it "can set its version" do
+      version = "1.4.2"
+      command.version version
+      expect(command.version).to eq(version)
+    end
+
     it "can set its syntax" do
       syntax_string = "my_name [options]"
       cmd = described_class.new(:my_name)


### PR DESCRIPTION
Now `Command`s can have versions. This makes it  a bit easier to be transparent about versions of subcommands of a program when they are shipped as separate gems.

Fixes #16.
