### PR TITLE
Pass `argv` and `config` to `default_command`

### DIFF
--- a/lib/mercenary/command.rb
+++ b/lib/mercenary/command.rb
@@ -215,7 +215,7 @@ module Mercenary
     # Returns nothing
     def execute(argv = [], config = {})
       if actions.empty? && !default_command.nil?
-        default_command.execute
+        default_command.execute(argv, config)
       else
         actions.each { |a| a.call(argv, config) }
       end


### PR DESCRIPTION
Resolves https://github.com/jekyll/mercenary/issues/31.

Seems like this should be enough, non? Works locally for my case, anyway.
