### PR TITLE
Use option object as key in the command's @map hash

### DIFF
--- a/lib/mercenary/command.rb
+++ b/lib/mercenary/command.rb
@@ -92,7 +92,7 @@ module Mercenary
     def option(sym, *options)
       new_option = Option.new(sym, options)
       @options << new_option
-      @map[new_option.hash] = sym
+      @map[new_option] = sym
     end
 
     # Public: Adds a subcommand
@@ -178,7 +178,7 @@ module Mercenary
     def process_options(opts, config)
       options.each do |option|
         opts.on(*option.for_option_parser) do |x|
-          config[map[option.hash]] = x
+          config[map[option]] = x
         end
       end
     end

--- a/lib/mercenary/option.rb
+++ b/lib/mercenary/option.rb
@@ -61,7 +61,7 @@ module Mercenary
     def hash
       instance_variables.map do |var|
         instance_variable_get(var).hash
-      end.reduce(:&)
+      end.reduce(:^)
     end
 
     # Public: Check equivalence of two Options based on equivalence of their


### PR DESCRIPTION
This fixes an intermittent problem that causes Mercenary to parse the completely wrong options. For example, I had a `--workers N` option. Every now and then — in fact, very often, sometimes on _every_run — I would end up with the rather curious options hash `{"show_version" => 2}`, when the command line was in fact `--workers 2`.

The reason is the use of `Option#hash` as the key in `@map`. The `hash` method used `&` to compute its hash, which of course vastly reduces the space of numbers and in fact tends to produce 0 — instead of the traditional `^` (XOR). So the likelyhood of having collisions is in fact extremely high.

This small patch changes the operator, but more importantly, uses the option object as the key, since the very simple `hash` function is not guaranteed to produce unique keys. (Doing `map[key.hash]` to store objects in a Ruby hash is never wise. The whole point of dynamically built hash tables is to be compact while support collisions.)

To illustrate the problem, the following script (without this patch) will show how fast you end up with a zero hash:

``` ruby
loop do
  s = ""
  rand(100).times do
    s << rand(100).to_s
  end
  if Mercenary::Option.new(:foo, ["-#{s}", s]).hash == 0
    puts "oops"
  end
end
```
