### PR TITLE
Presenter: Options should include those from parent command

### DIFF
--- a/lib/mercenary/presenter.rb
+++ b/lib/mercenary/presenter.rb
@@ -22,8 +22,22 @@ module Mercenary
     #
     # Returns the string representation of the options
     def options_presentation
+      return nil unless command_options_presentation || parent_command_options_presentation
+      [command_options_presentation, parent_command_options_presentation].compact.join("\n")
+    end
+
+    def command_options_presentation
       return nil unless command.options.size > 0
       command.options.map(&:to_s).join("\n")
+    end
+
+    # Public: Builds a string representation of the options for parent
+    # commands
+    #
+    # Returns the string representation of the options for parent commands
+    def parent_command_options_presentation
+      return nil unless command.parent
+      Presenter.new(command.parent).options_presentation
     end
 
     # Public: Builds a string representation of the subcommands


### PR DESCRIPTION
Not sure if this should always be the case or only if the parent command is a `Program`, but when you run `jekyll serve`, you get access to all the options for both `jekyll` and `jekyll serve`. When you run `jekyll serve --help`, however, you only see the options from `jekyll serve`, not from `jekyll`.

This PR adds them into the listing. Should help reduce duplication, too.

## Before

```text
jekyll serve -- Serve your site locally

Usage:

  jekyll serve [options]

Options:
            --config CONFIG_FILE[,CONFIG_FILE2,...]  Custom configuration file
        -d, --destination DESTINATION  The current folder will be generated into DESTINATION
        -s, --source SOURCE  Custom source directory
            --future       Publishes posts with a future date
            --limit_posts MAX_POSTS  Limits the number of posts to parse and publish
        -w, --[no-]watch   Watch for changes and rebuild
            --force_polling  Force watch to use polling
            --lsi          Use LSI for improved related posts
        -D, --drafts       Render posts in the _drafts folder
            --unpublished  Render posts that were marked as unpublished
        -q, --quiet        Silence output.
        -V, --verbose      Print verbose output.
        -I, --incremental  Enable incremental rebuild.
            --ssl-cert [CERT]  X.509 (SSL) certificate.
        -H, --host [HOST]  Host to bind to
        -o, --open-url     Launch your browser with your site.
        -B, --detach       Run the server in the background (detach)
            --ssl-key [KEY]  X.509 (SSL) Private Key.
        -P, --port [PORT]  Port to listen on
        -b, --baseurl [URL]  Base URL
            --show-dir-listing  Show a directory listing instead of loading your index file.
            --skip-initial-build  Skips the initial site build which occurs before the server is started.
        -h, --help         Show this message
        -v, --version      Print the name and version
        -t, --trace        Show the full backtrace when an error occurs
```

## After

```text
jekyll serve -- Serve your site locally

Usage:

  jekyll serve [options]

Options:
            --config CONFIG_FILE[,CONFIG_FILE2,...]  Custom configuration file
        -d, --destination DESTINATION  The current folder will be generated into DESTINATION
        -s, --source SOURCE  Custom source directory
            --future       Publishes posts with a future date
            --limit_posts MAX_POSTS  Limits the number of posts to parse and publish
        -w, --[no-]watch   Watch for changes and rebuild
            --force_polling  Force watch to use polling
            --lsi          Use LSI for improved related posts
        -D, --drafts       Render posts in the _drafts folder
            --unpublished  Render posts that were marked as unpublished
        -q, --quiet        Silence output.
        -V, --verbose      Print verbose output.
        -I, --incremental  Enable incremental rebuild.
            --ssl-cert [CERT]  X.509 (SSL) certificate.
        -H, --host [HOST]  Host to bind to
        -o, --open-url     Launch your browser with your site.
        -B, --detach       Run the server in the background (detach)
            --ssl-key [KEY]  X.509 (SSL) Private Key.
        -P, --port [PORT]  Port to listen on
        -b, --baseurl [URL]  Base URL
            --show-dir-listing  Show a directory listing instead of loading your index file.
            --skip-initial-build  Skips the initial site build which occurs before the server is started.
        -h, --help         Show this message
        -v, --version      Print the name and version
        -t, --trace        Show the full backtrace when an error occurs
        -s, --source [DIR]  Source directory (defaults to ./)
        -d, --destination [DIR]  Destination directory (defaults to ./_site)
            --safe         Safe mode (defaults to false)
        -p, --plugins PLUGINS_DIR1[,PLUGINS_DIR2[,...]]  Plugins directory (defaults to ./_plugins)
            --layouts DIR  Layouts directory (defaults to ./_layouts)
            --profile      Generate a Liquid rendering profile
        -h, --help         Show this message
        -v, --version      Print the name and version
        -t, --trace        Show the full backtrace when an error occurs
```