### PR TITLE
Fix default command options

### DIFF
--- a/lib/mercenary/command.rb
+++ b/lib/mercenary/command.rb
@@ -162,6 +162,9 @@ module Mercenary
         logger.debug "Found subcommand '#{cmd.name}'"
         argv.shift
         cmd.go(argv, opts, config)
+      elsif !(argv[0] =~ /^\-/).nil? && @default_command
+        logger.debug "Default command found.'"
+        @default_command.go(argv, opts, config)
       else
         logger.debug "No additional command found, time to exec"
         self


### PR DESCRIPTION
Use case :

``` ruby
Mercenary.program(:myProgram) do |program|
  # ...

  program.command(:default) do |command|
    # ...
    command.option :myOption, '-o ARG', '--option ARG', 'Option'
    command.action { |_, options| puts options }
  end

  program.default_command(:default)
end
```
## Before the change

[x] Work: `./exe/program`
[x] Work: `./exe/program default --option='FOO'`
[  ] Not work: `./exe/program --option='FOO'`
## After the change

[x] Work: `./exe/program`
[x] Work: `./exe/program default --option='FOO'`
[x] Work: `./exe/program --option='FOO'`
