### PR TITLE
Introduce visual separation to improve readability

### DIFF
--- a/lib/mercenary/presenter.rb
+++ b/lib/mercenary/presenter.rb
@@ -23,7 +23,7 @@ module Mercenary
     # Returns the string representation of the options
     def options_presentation
       return nil unless command_options_presentation || parent_command_options_presentation
-      [command_options_presentation, parent_command_options_presentation].compact.join("\n")
+      [command_options_presentation, parent_command_options_presentation].join("\n\n").rstrip
     end
 
     def command_options_presentation
@@ -37,7 +37,7 @@ module Mercenary
     # Returns the string representation of the options for parent commands
     def parent_command_options_presentation
       return nil unless command.parent
-      Presenter.new(command.parent).options_presentation
+      Presenter.new(command.parent).command_options_presentation
     end
 
     # Public: Builds a string representation of the subcommands
@@ -52,7 +52,7 @@ module Mercenary
     #
     # Returns the command header as a String
     def command_header
-      header = "#{command.identity}"
+      header = "\n#{command.identity}"
       header << " -- #{command.description}" if command.description
       header
     end


### PR DESCRIPTION
Introduce subtle visual separation to improve readability
  - add a newline between execution line and start of Header
  - add a newline between command-options and parent-command-options

### Before:

![mercen1](https://cloud.githubusercontent.com/assets/12479464/22859335/22c4a26c-f0fe-11e6-930d-4e015a54e01f.png)

### After:

![mercen2](https://cloud.githubusercontent.com/assets/12479464/22859341/4b228544-f0fe-11e6-9f6b-f6c979bea66e.png)

--
/cc @parkr 