### PR TITLE
Adopt Jekyll's rubocop config for consistency

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,174 @@
+---
+AllCops:
+  TargetRubyVersion: 2.0
+  Exclude:
+    - vendor/**/*
+Layout/AlignArray:
+  Enabled: false
+Layout/AlignHash:
+  EnforcedHashRocketStyle: table
+Layout/AlignParameters:
+  Enabled: false
+Layout/EmptyLinesAroundAccessModifier:
+  Enabled: false
+Layout/EmptyLinesAroundModuleBody:
+  Enabled: false
+Layout/EndOfLine:
+  EnforcedStyle: native
+Layout/ExtraSpacing:
+  AllowForAlignment: true
+Layout/FirstParameterIndentation:
+  EnforcedStyle: consistent
+Layout/IndentationWidth:
+  Severity: error
+Layout/IndentArray:
+  EnforcedStyle: consistent
+Layout/IndentHash:
+  EnforcedStyle: consistent
+Layout/IndentHeredoc:
+  Enabled: false
+  Exclude:
+      - spec/**/*
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+Layout/MultilineOperationIndentation:
+  EnforcedStyle: indented
+Layout/SpaceAroundOperators:
+  Enabled: true
+Layout/SpaceInsideBrackets:
+  Enabled: false
+Lint/AssignmentInCondition:
+  Exclude:
+    - lib/mercenary/command.rb
+    - lib/mercenary/option.rb
+    - lib/mercenary/presenter.rb
+Lint/DuplicateMethods:
+  Exclude:
+    - lib/mercenary/command.rb
+Lint/EndAlignment:
+  Severity: error
+Lint/HandleExceptions:
+  Exclude:
+    - lib/mercenary/option.rb
+Lint/RescueWithoutErrorClass:
+  Enabled: false
+  Exclude:
+    - lib/mercenary/program.rb
+Lint/UselessAssignment:
+  Exclude:
+    - lib/mercenary/presenter.rb
+Lint/UnreachableCode:
+  Severity: error
+Lint/UselessAccessModifier:
+  Enabled: false
+Lint/Void:
+  Enabled: false
+Metrics/AbcSize:
+  Max: 21
+  Exclude:
+    - lib/mercenary/program.rb
+Metrics/BlockLength:
+  Exclude:
+    - examples/**/*
+    - spec/**/*
+Metrics/ClassLength:
+  Max: 300
+Metrics/CyclomaticComplexity:
+  Max: 9
+Metrics/LineLength:
+  Exclude:
+    - lib/mercenary/command.rb
+    - lib/mercenary/presenter.rb
+    - lib/mercenary/program.rb
+    - examples/**/*
+    - spec/**/*
+    - mercenary.gemspec
+  Max: 90
+  Severity: warning
+Metrics/MethodLength:
+  Exclude:
+    - lib/mercenary/program.rb
+  CountComments: false
+  Max: 20
+  Severity: error
+Metrics/ModuleLength:
+  Max: 240
+Metrics/ParameterLists:
+  Max: 4
+Metrics/PerceivedComplexity:
+  Max: 8
+Naming/FileName:
+  Enabled: false
+Naming/HeredocDelimiterNaming:
+  Enabled: false
+Naming/PredicateName:
+  Exclude:
+    - lib/mercenary/command.rb
+Style/Alias:
+  Enabled: false
+Style/AndOr:
+  Severity: error
+Style/Attr:
+  Enabled: false
+Style/BracesAroundHashParameters:
+  Enabled: false
+Style/ClassAndModuleChildren:
+  Enabled: false
+Style/FrozenStringLiteralComment:
+  Exclude:
+    - lib/mercenary/command.rb
+  Enabled: true
+  EnforcedStyle: always
+Style/Documentation:
+  Enabled: false
+Style/DoubleNegation:
+  Enabled: false
+Style/Encoding:
+  EnforcedStyle: when_needed
+Style/GuardClause:
+  Enabled: false
+Style/HashSyntax:
+  EnforcedStyle: hash_rockets
+  Severity: error
+Style/IfUnlessModifier:
+  Enabled: false
+Style/InverseMethods:
+  Enabled: false
+Style/MethodMissing:
+  Exclude:
+    - lib/mercenary/presenter.rb
+Style/ModuleFunction:
+  Enabled: false
+Style/MultilineTernaryOperator:
+  Severity: error
+Style/PercentLiteralDelimiters:
+  PreferredDelimiters:
+    "%q": "{}"
+    "%Q": "{}"
+    "%r": "!!"
+    "%s": "()"
+    "%w": "()"
+    "%W": "()"
+    "%x": "()"
+Style/RedundantReturn:
+  Enabled: false
+Style/RedundantSelf:
+  Enabled: false
+Style/RegexpLiteral:
+  EnforcedStyle: percent_r
+Style/RescueModifier:
+  Enabled: false
+Style/SignalException:
+  EnforcedStyle: only_raise
+Style/SingleLineMethods:
+  Enabled: false
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+Style/StringLiteralsInInterpolation:
+  EnforcedStyle: double_quotes
+Style/SymbolArray:
+  Enabled: false
+Style/TrailingCommaInLiteral:
+  EnforcedStyleForMultiline: consistent_comma
+Style/UnneededCapitalW:
+  Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,14 @@
 language: ruby
 rvm:
-  - 1.9.3
-  - 2.0.0
+  - 2.0
   - 2.1
+  - 2.2
+  - 2.3
+  - 2.4
 sudo: false
 cache: bundler
 before_script: bundle update
-script: "./script/cibuild"
+script: script/cibuild
 notifications:
   email:
     recipients:

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,6 @@
-source 'https://rubygems.org'
+# frozen_string_literal: true
+
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in mercenary.gemspec
 gemspec

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2013-2014 Parker Moore
+Copyright (c) 2013-2017 Parker Moore
 
 MIT License
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 require "bundler/gem_tasks"

--- a/examples/help_dialogue.rb
+++ b/examples/help_dialogue.rb
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
-$:.unshift File.join(File.dirname(__FILE__), *%w{ .. lib })
+$LOAD_PATH.unshift File.join(__dir__, "..", "lib")
 
 require "mercenary"
 
@@ -9,23 +10,22 @@ require "mercenary"
 # be output to STDOUT.
 
 Mercenary.program(:help_dialogue) do |p|
-
   p.version "2.0.1"
-  p.description 'An example of the help dialogue in Mercenary'
-  p.syntax 'help_dialogue <subcommand>'
+  p.description "An example of the help dialogue in Mercenary"
+  p.syntax "help_dialogue <subcommand>"
 
   p.command(:some_subcommand) do |c|
-    c.version '1.4.2'
-    c.syntax 'some_subcommand <subcommand> [options]'
-    c.description 'Some subcommand to do something'
-    c.option 'an_option', '-o', '--option', 'Some option'
+    c.version "1.4.2"
+    c.syntax "some_subcommand <subcommand> [options]"
+    c.description "Some subcommand to do something"
+    c.option "an_option", "-o", "--option", "Some option"
     c.alias(:blah)
 
     c.command(:yet_another_sub) do |f|
-      f.syntax 'yet_another_sub [options]'
-      f.description 'Do amazing things'
-      f.option 'blah', '-b', '--blah', 'Trigger blah flag'
-      f.option 'heh', '-H ARG', '--heh ARG', 'Give a heh'
+      f.syntax "yet_another_sub [options]"
+      f.description "Do amazing things"
+      f.option "blah", "-b", "--blah", "Trigger blah flag"
+      f.option "heh", "-H ARG", "--heh ARG", "Give a heh"
 
       f.action do |args, options|
         print "Args: "
@@ -37,10 +37,9 @@ Mercenary.program(:help_dialogue) do |p|
   end
 
   p.command(:another_subcommand) do |c|
-    c.syntax 'another_subcommand <subcommand> [options]'
-    c.description 'Another subcommand to do something different.'
-    c.option 'an_option', '-O', '--option', 'Some option'
-    c.option 'another_options', '--pluginzzz', 'Set where the plugins should be found from'
+    c.syntax "another_subcommand <subcommand> [options]"
+    c.description "Another subcommand to do something different."
+    c.option "an_option", "-O", "--option", "Some option"
+    c.option "another_options", "--pluginzzz", "Set where the plugins should be found from"
   end
-
 end

--- a/examples/logging.rb
+++ b/examples/logging.rb
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
-$:.unshift File.join(File.dirname(__FILE__), *%w{ .. lib })
+$LOAD_PATH.unshift File.join(__dir__, "..", "lib")
 
 require "mercenary"
 
@@ -9,18 +10,16 @@ require "mercenary"
 # be output to STDOUT.
 
 Mercenary.program(:logger_output) do |p|
-
   p.version "5.2.6"
-  p.description 'An example of turning on logging for Mercenary.'
-  p.syntax 'logger_output'
-
+  p.description "An example of turning on logging for Mercenary."
+  p.syntax "logger_output"
 
   p.logger.info "The default log level is INFO. So this will output."
   p.logger.debug "Since DEBUG is below INFO, this will not output."
 
   p.logger(Logger::DEBUG)
   p.logger.debug "Logger level now set to DEBUG. So everything will output."
-  
+
   p.logger.debug    "Example of DEBUG level message."
   p.logger.info     "Example of INFO level message."
   p.logger.warn     "Example of WARN level message."
@@ -28,12 +27,9 @@ Mercenary.program(:logger_output) do |p|
   p.logger.fatal    "Example of FATAL level message."
   p.logger.unknown  "Example of UNKNOWN level message."
 
-  p.action do |args, options|
-    
+  p.action do |_args, _options|
     p.logger(Logger::INFO)
     p.logger.debug "Logger level back to INFO. This line will not output."
     p.logger.info "This INFO message will output."
-
   end
-
 end

--- a/examples/trace.rb
+++ b/examples/trace.rb
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
-$:.unshift File.join(File.dirname(__FILE__), *%w{ .. lib })
+$LOAD_PATH.unshift File.join(__dir__, "..", "lib")
 
 require "mercenary"
 
@@ -9,13 +10,11 @@ require "mercenary"
 # be output to STDOUT.
 
 Mercenary.program(:trace) do |p|
-
   p.version "2.0.1"
-  p.description 'An example of traces in Mercenary'
-  p.syntax 'trace <subcommand>'
+  p.description "An example of traces in Mercenary"
+  p.syntax "trace <subcommand>"
 
   p.action do |_, _|
-    raise ArgumentError.new("YOU DID SOMETHING TERRIBLE YOU BUFFOON")
+    raise ArgumentError, "YOU DID SOMETHING TERRIBLE YOU BUFFOON"
   end
-
 end

--- a/lib/mercenary.rb
+++ b/lib/mercenary.rb
@@ -1,12 +1,14 @@
-require File.expand_path("../mercenary/version", __FILE__)
+# frozen_string_literal: true
+
+require File.expand_path("mercenary/version", __dir__)
 require "optparse"
 require "logger"
 
 module Mercenary
-  autoload :Command,   File.expand_path("../mercenary/command", __FILE__)
-  autoload :Option,    File.expand_path("../mercenary/option", __FILE__)
-  autoload :Presenter, File.expand_path("../mercenary/presenter", __FILE__)
-  autoload :Program,   File.expand_path("../mercenary/program", __FILE__)
+  autoload :Command,   File.expand_path("mercenary/command", __dir__)
+  autoload :Option,    File.expand_path("mercenary/option", __dir__)
+  autoload :Presenter, File.expand_path("mercenary/presenter", __dir__)
+  autoload :Program,   File.expand_path("mercenary/program", __dir__)
 
   # Public: Instantiate a new program and execute.
   #

--- a/lib/mercenary/command.rb
+++ b/lib/mercenary/command.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: false
+
 module Mercenary
   class Command
     attr_reader :name
@@ -48,7 +50,7 @@ module Mercenary
       @syntax = syntax if syntax
       syntax_list = []
       if parent
-        syntax_list << parent.syntax.to_s.gsub(/<[\w\s-]+>/, '').gsub(/\[[\w\s-]+\]/, '').strip
+        syntax_list << parent.syntax.to_s.gsub(%r!<[\w\s-]+>!, "").gsub(%r!\[[\w\s-]+\]!, "").strip
       end
       syntax_list << (@syntax || name.to_s)
       syntax_list.join(" ")
@@ -72,11 +74,11 @@ module Mercenary
     # Returns the default command if there is one, `nil` otherwise
     def default_command(command_name = nil)
       if command_name
-        if commands.has_key?(command_name)
+        if commands.key?(command_name)
           @default_command = commands[command_name] if command_name
           @default_command
         else
-          raise ArgumentError.new("'#{command_name}' couldn't be found in this command's list of commands.")
+          raise ArgumentError, "'#{command_name}' couldn't be found in this command's list of commands."
         end
       else
         @default_command
@@ -133,11 +135,12 @@ module Mercenary
     # level - the logger level (a Logger constant, see docs for more info)
     #
     # Returns the instance of Logger
+
     def logger(level = nil)
       unless @logger
         @logger = Logger.new(STDOUT)
         @logger.level = level || Logger::INFO
-        @logger.formatter = proc do |severity, datetime, progname, msg|
+        @logger.formatter = proc do |severity, _datetime, _progname, msg|
           "#{identity} | " << "#{severity.downcase.capitalize}:".ljust(7) << " #{msg}\n"
         end
       end
@@ -189,15 +192,15 @@ module Mercenary
     #
     # Returns nothing
     def add_default_options(opts)
-      option 'show_help', '-h', '--help', 'Show this message'
-      option 'show_version', '-v', '--version', 'Print the name and version'
-      option 'show_backtrace', '-t', '--trace', 'Show the full backtrace when an error occurs'
+      option "show_help", "-h", "--help", "Show this message"
+      option "show_version", "-v", "--version", "Print the name and version"
+      option "show_backtrace", "-t", "--trace", "Show the full backtrace when an error occurs"
       opts.on("-v", "--version", "Print the version") do
         puts "#{name} #{version}"
         exit(0)
       end
 
-      opts.on('-t', '--trace', 'Show full backtrace if an error occurs') do
+      opts.on("-t", "--trace", "Show full backtrace if an error occurs") do
         @trace = true
       end
 

--- a/lib/mercenary/option.rb
+++ b/lib/mercenary/option.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Mercenary
   class Option
     attr_reader :config_key, :description, :short, :long, :return_type
@@ -11,10 +13,10 @@ module Mercenary
     #
     # Returns nothing
     def initialize(config_key, info)
-      @config_key  = config_key
+      @config_key = config_key
       while arg = info.shift
         begin
-          @return_type = Object.const_get("#{arg}")
+          @return_type = Object.const_get(arg.to_s)
           next
         rescue NameError
         end
@@ -34,7 +36,7 @@ module Mercenary
     #
     # Returns the array which OptionParser#on wants
     def for_option_parser
-      [short, long, return_type, description].flatten.reject{ |o| o.to_s.empty? }
+      [short, long, return_type, description].flatten.reject { |o| o.to_s.empty? }
     end
 
     # Public: Build a string representation of this option including the
@@ -51,8 +53,8 @@ module Mercenary
     def formatted_switches
       [
         switches.first.rjust(10),
-        switches.last.ljust(13)
-      ].join(", ").gsub(/ , /, '   ').gsub(/,   /, '    ')
+        switches.last.ljust(13),
+      ].join(", ").gsub(%r! , !, "   ").gsub(%r!,   !, "    ")
     end
 
     # Public: Hash based on the hash value of instance variables
@@ -82,6 +84,5 @@ module Mercenary
     def switches
       [short, long].map(&:to_s)
     end
-
   end
 end

--- a/lib/mercenary/presenter.rb
+++ b/lib/mercenary/presenter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Mercenary
   class Presenter
     attr_accessor :command
@@ -27,7 +29,7 @@ module Mercenary
     end
 
     def command_options_presentation
-      return nil unless command.options.size > 0
+      return nil if command.options.empty?
       command.options.map(&:to_s).join("\n")
     end
 
@@ -44,7 +46,7 @@ module Mercenary
     #
     # Returns the string representation of the subcommands
     def subcommands_presentation
-      return nil unless command.commands.size > 0
+      return nil if command.commands.empty?
       command.commands.values.uniq.map(&:summarize).join("\n")
     end
 
@@ -52,7 +54,7 @@ module Mercenary
     #
     # Returns the command header as a String
     def command_header
-      header = "#{command.identity}"
+      header = command.identity.to_s
       header << " -- #{command.description}" if command.description
       header
     end
@@ -83,11 +85,12 @@ module Mercenary
     #
     # Returns the value of whatever function is called
     def method_missing(meth, *args, &block)
-      if meth.to_s =~ /^print_(.+)$/
-        send("#{$1.downcase}_presentation")
+      if meth.to_s =~ %r!^print_(.+)$!
+        send("#{Regexp.last_match(1).downcase}_presentation")
       else
-        super # You *must* call super if you don't handle the method,
-              # otherwise you'll mess up Ruby's method lookup.
+        # You *must* call super if you don't handle the method,
+        # otherwise you'll mess up Ruby's method lookup.
+        super
       end
     end
   end

--- a/lib/mercenary/program.rb
+++ b/lib/mercenary/program.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Mercenary
   class Program < Command
     attr_reader :optparse
@@ -31,7 +33,7 @@ module Mercenary
         @optparse.parse!(argv)
       rescue OptionParser::InvalidOption => e
         logger.error "Whoops, we can't understand your command."
-        logger.error "#{e.message}"
+        logger.error e.message.to_s
         logger.error "Run your command again with the --help switch to see available options."
         abort
       end

--- a/lib/mercenary/version.rb
+++ b/lib/mercenary/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Mercenary
-  VERSION = "0.3.6"
+  VERSION = "0.3.6".freeze
 end

--- a/mercenary.gemspec
+++ b/mercenary.gemspec
@@ -1,24 +1,26 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+# frozen_string_literal: true
+
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'mercenary/version'
+require "mercenary/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "mercenary"
   spec.version       = Mercenary::VERSION
   spec.authors       = ["Tom Preston-Werner", "Parker Moore"]
   spec.email         = ["tom@mojombo.com", "parkrmoore@gmail.com"]
-  spec.description   = %q{Lightweight and flexible library for writing command-line apps in Ruby.}
-  spec.summary       = %q{Lightweight and flexible library for writing command-line apps in Ruby.}
+  spec.description   = "Lightweight and flexible library for writing command-line apps in Ruby."
+  spec.summary       = "Lightweight and flexible library for writing command-line apps in Ruby."
   spec.homepage      = "https://github.com/jekyll/mercenary"
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files`.split($/)
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
+  spec.executables   = spec.files.grep(%r!^bin/!) { |f| File.basename(f) }
+  spec.test_files    = spec.files.grep(%r!^(test|spec|features)/!)
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "rubocop", "~> 0.5"
 end

--- a/script/cibuild
+++ b/script/cibuild
@@ -3,4 +3,5 @@
 set -ex
 
 bundle exec rspec
-./script/examples
+script/fmt
+script/examples

--- a/script/fmt
+++ b/script/fmt
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "Rubocop $(bundle exec rubocop --version)"
+bundle exec rubocop -S -D -E $@

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -1,7 +1,8 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe(Mercenary::Command) do
-
   context "a basic command" do
     let(:command) { Mercenary::Command.new(:my_name) }
     let(:parent)  { Mercenary::Command.new(:my_parent) }
@@ -17,7 +18,7 @@ describe(Mercenary::Command) do
       )
     end
     let(:add_sub) do
-      Proc.new do |c|
+      proc do |c|
         c.command(:sub_command) { |p| }
       end
     end
@@ -56,7 +57,7 @@ describe(Mercenary::Command) do
 
     it "can set its options" do
       name = "show_drafts"
-      opts  = ['--drafts', 'Render posts in the _drafts folder']
+      opts = ["--drafts", "Render posts in the _drafts folder"]
       option = Mercenary::Option.new(name, opts)
       command.option name, *opts
       expect(command.options).to eql([option])
@@ -68,7 +69,7 @@ describe(Mercenary::Command) do
     end
 
     it "knows its identity" do
-      command_with_parent.version '1.8.7'
+      command_with_parent.version "1.8.7"
       expect(command_with_parent.identity).to eql("my_parent i_have_parent 1.8.7")
     end
 
@@ -94,5 +95,4 @@ describe(Mercenary::Command) do
       end
     end
   end
-
 end

--- a/spec/option_spec.rb
+++ b/spec/option_spec.rb
@@ -1,9 +1,11 @@
-require 'spec_helper'
+# frozen_string_literal: true
+
+require "spec_helper"
 
 describe(Mercenary::Option) do
   let(:config_key)  { "largo" }
   let(:description) { "This is a description" }
-  let(:switches)    { ['-l', '--largo'] }
+  let(:switches)    { ["-l", "--largo"] }
   let(:option)      { described_class.new(config_key, [switches, description].flatten.reject(&:nil?)) }
 
   it "knows its config key" do
@@ -27,20 +29,20 @@ describe(Mercenary::Option) do
   end
 
   it "compares itself with other options well" do
-    new_option = described_class.new(config_key, ['-l', '--largo', description])
+    new_option = described_class.new(config_key, ["-l", "--largo", description])
     expect(option.eql?(new_option)).to be(true)
     expect(option.hash.eql?(new_option.hash)).to be(true)
   end
 
   it "has a custom #hash" do
-    expect(option.hash.to_s).to match(/\d+/)
+    expect(option.hash.to_s).to match(%r!\d+!)
   end
 
   context "with just the long switch" do
-    let(:switches) { ['--largo'] }
+    let(:switches) { ["--largo"] }
 
     it "adds an empty string in place of the short switch" do
-      expect(option.switches).to eql(['', '--largo'])
+      expect(option.switches).to eql(["", "--largo"])
     end
 
     it "sets its description properly" do
@@ -53,10 +55,10 @@ describe(Mercenary::Option) do
   end
 
   context "with just the short switch" do
-    let(:switches) { ['-l'] }
+    let(:switches) { ["-l"] }
 
     it "adds an empty string in place of the long switch" do
-      expect(option.switches).to eql(['-l', ''])
+      expect(option.switches).to eql(["-l", ""])
     end
 
     it "sets its description properly" do
@@ -79,5 +81,4 @@ describe(Mercenary::Option) do
       expect(option.switches).to eql(switches)
     end
   end
-
 end

--- a/spec/presenter_spec.rb
+++ b/spec/presenter_spec.rb
@@ -1,4 +1,6 @@
-require 'spec_helper'
+# frozen_string_literal: true
+
+require "spec_helper"
 
 describe(Mercenary::Presenter) do
   let(:supercommand) { Mercenary::Command.new(:script_name) }
@@ -6,10 +8,10 @@ describe(Mercenary::Presenter) do
   let(:presenter) { described_class.new(command) }
 
   before(:each) do
-    command.version '1.4.2'
-    command.description 'Do all the things.'
-    command.option 'one', '-1', '--one', 'The first option'
-    command.option 'two', '-2', '--two', 'The second option'
+    command.version "1.4.2"
+    command.description "Do all the things."
+    command.option "one", "-1", "--one", "The first option"
+    command.option "two", "-2", "--two", "The second option"
     command.alias :cmd
     supercommand.commands[command.name] = command
   end

--- a/spec/program_spec.rb
+++ b/spec/program_spec.rb
@@ -1,7 +1,8 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe(Mercenary::Program) do
-
   context "a basic program" do
     let(:program) { Mercenary::Program.new(:my_name) }
 
@@ -15,5 +16,4 @@ describe(Mercenary::Program) do
       expect(program.version).to eq(version)
     end
   end
-
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,8 @@
-lib = File.expand_path('../../lib', __FILE__)
+# frozen_string_literal: true
+
+lib = File.expand_path("../lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'mercenary'
+require "mercenary"
 
 RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
@@ -10,5 +12,5 @@ RSpec.configure do |config|
   # order dependency and want to debug it, you can fix the order by providing
   # the seed, which is printed after each run.
   #     --seed 1234
-  config.order = 'random'
+  config.order = "random"
 end


### PR DESCRIPTION
Our friend 🤖  strikes again 😄 

- [x] add `rubocop ~0.5` as a development dependency in `gemspec` who requires Ruby > 2.0
- [x] inherit from Jekyll's config
- [x] use `__dir__` instead of `File.dirname(__FILE__)`
- [x] add `script/fmt` to CI
- [x] exclude remaining offended files in `.rubocop.yml`
