### PR TITLE
fixes the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,9 @@ Fetches the program configuration hash.
 
 #### `#new`
 
-Create a new command. Accepts two arguments:
+Create a new command. Accepts one argument:
 
 - `name` - the name of your command, as a symbol
-- `parent` - (optional) the parent Command
 
 #### `#version`
 
@@ -167,7 +166,7 @@ different class to create, e.g. `Array`, if you are expecting a particular class
 in your code from this option's value. The description is also optional, but
 it's highly recommended to include a description.
 
-#### `#alias` 
+#### `#alias`
 
 Specifies an alias for this command such that the alias may be used in place of
 the command during execution. Accepts one argument:


### PR DESCRIPTION
Changes the explanation about the new command arguments since it’s not needed nor possible to provide the parent name this way.