### PR TITLE
Remove superfluous items from gem package

### DIFF
--- a/mercenary.gemspec
+++ b/mercenary.gemspec
@@ -14,9 +14,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/jekyll/mercenary"
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR).grep_v(%r!^spec/!)
-  spec.executables   = spec.files.grep(%r!^bin/!) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r!^(test|spec|features)/!)
+  spec.files         = `git ls-files lib History.markdown LICENSE.txt README.md`.split($INPUT_RECORD_SEPARATOR)
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 2.4.0"

--- a/mercenary.gemspec
+++ b/mercenary.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/jekyll/mercenary"
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
+  spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR).grep_v(%r!^spec/!)
   spec.executables   = spec.files.grep(%r!^bin/!) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r!^(test|spec|features)/!)
   spec.require_paths = ["lib"]


### PR DESCRIPTION
Here's a patch that excludes files under spec directory from the gem package.

With this patch, the gem package size shrinks as follows:
```
before: 18944 bytes
after:  16896 bytes
```