### PR TITLE
Update CI workflow to test with Ruby 3.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         ruby_version:
           - 2.7
-          - 3.3
+          - 3.4
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
       matrix:
         ruby_version:
           - 2.7
+          - 3.3
           - 3.4
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This pull request  updates the max Ruby version in the CI matrix to 3.4.

The `script/cibuild` script includes `script/fmt` for running RuboCop, which overlapped with the `style_check` job in GitHub Actions.
To avoid duplication, `script/fmt` has been removed from `script/cibuild`.

~~Additionally, the `actions/checkout` step in GitHub Actions has been updated to v4.~~

~~Lastly, the outdated Travis CI configuration file, which is no longer in use, has been removed.~~
